### PR TITLE
Check if command is installed

### DIFF
--- a/tokei.el
+++ b/tokei.el
@@ -149,6 +149,8 @@ Data is provided via the JSON argument"
 (defun tokei ()
   "Show codebase statistics."
   (interactive)
+  (unless (executable-find tokei-program)
+    (user-error "command not found: %s" tokei-program))
   (switch-to-buffer (generate-new-buffer "*tokei*"))
   (tokei-mode))
 


### PR DESCRIPTION
If the command is not installed, then following error message outputs after switching buffer. I suppose that checking if `tokei-program` is installed is good for users before switching buffer. 

```
=: Searching for program: No such file or directory, tokei
Error in post-command-hook (magit-section-post-command-hook): (wrong-type-argument (or eieio-object cl-structure-object\
 oclosure) nil)
```